### PR TITLE
[FIX] Missing keyword git_url in settings.ini template

### DIFF
--- a/easyrelease/templates/settings_template.ini
+++ b/easyrelease/templates/settings_template.ini
@@ -1,5 +1,7 @@
 [DEFAULT]
 host = github
+# github url
+git_url = 
 # e.g. easyrelease
 lib_name = 
 # github user


### PR DESCRIPTION
This fixes #39 